### PR TITLE
fix leveldown build

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Electron Main",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
+      "program": "${workspaceFolder}/main.js",
+      "env": {
+        "ELECTRON_NO_ASAR": null
+      },
+      "protocol": "inspector"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A minimal electron application running with a scuttlebot server",
   "main": "main.js",
   "scripts": {
-    "start": "electron ."
+    "start": "electron .",
+    "postinstall": "electron-rebuild -w leveldown"
   },
   "repository": "https://github.com/kgibb8/scuttletron",
   "keywords": [
@@ -19,7 +20,8 @@
   ],
   "author": "kgibb8",
   "devDependencies": {
-    "electron": "^1.8.4"
+    "electron": "^1.8.6",
+    "electron-rebuild": "~1.7.0"
   },
   "dependencies": {
     "depnest": "^1.3.0",


### PR DESCRIPTION
This is great, thanks @KGibb8!

Electron wouldn't come up on npm start which I tracked down to leveldown and it turns out it was the same issue as here: https://github.com/Level/leveldown/issues/239

This postinstall script to rebuild leveldown does the trick and it's working now, thanks again :)

